### PR TITLE
updated create service accounts to add the anthosgke api and updated …

### DIFF
--- a/anthos/create_service_accounts.sh
+++ b/anthos/create_service_accounts.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+
+#start the interactive portion to capture user details
 echo "This script will help you perform the setps outlined at https://cloud.google.com/gke-on-prem/docs/how-to/service-accounts \nYou will be provided the option to create a storage reader service account as well. \n\n"
 echo "Enter the name of the email of your whitelisted service account \n (example: whitelisted@my-anthos-project.iam.gserviceaccount.com):"
 read WL_SA_EMAIL
@@ -8,24 +11,43 @@ if [ $STORAGE_OPTION = "y" ]; then
     echo "Provide Project where GCS Bucket Lives"
     read STORAGE_PROJECT
 fi
+
+
+#log in to gcloud
 gcloud init
+
+#capture the project the user selected during log in
 PROJECT=$(gcloud config list --format 'value(core.project)')
+
+#create the folder for the keys and set the variable
 FOLDER='gcp_keys'
 mkdir -p ./$FOLDER
+
+#create the needed service accounts
 gcloud iam service-accounts create register-service-account --project $PROJECT
 gcloud iam service-accounts create connect-service-account --project $PROJECT
 gcloud iam service-accounts create stackdriver-service-account --project $PROJECT
+
+#create the needed keys
 gcloud iam service-accounts keys create ./$FOLDER/register-key.json --iam-account  register-service-account@$PROJECT.iam.gserviceaccount.com 
 gcloud iam service-accounts keys create ./$FOLDER/connect-key.json --iam-account  connect-service-account@$PROJECT.iam.gserviceaccount.com 
 gcloud iam service-accounts keys create ./$FOLDER/stackdriver-key.json --iam-account  stackdriver-service-account@$PROJECT.iam.gserviceaccount.com 
 gcloud iam service-accounts keys create ./$FOLDER/whitelisted-key.json --iam-account  $WL_SA_EMAIL
+
+#assign the needed IAM roles
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:connect-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/gkehub.connect'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:register-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/gkehub.admin'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:register-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/serviceusage.serviceUsageViewer'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:stackdriver-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/stackdriver.resourceMetadata.writer'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:stackdriver-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/logging.logWriter'
 gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:stackdriver-service-account@$PROJECT.iam.gserviceaccount.com" --role='roles/monitoring.metricWriter'
+gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$WL_SA_EMAIL" --role="roles/serviceusage.serviceUsageViewer"
+gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$WL_SA_EMAIL" --role="roles/iam.serviceAccountUser"
+gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$WL_SA_EMAIL" --role="roles/iam.roleViewer"
 
+
+
+#enable the required APIs for the project
 gcloud services enable --project $PROJECT \
     cloudresourcemanager.googleapis.com \
     container.googleapis.com \
@@ -34,12 +56,13 @@ gcloud services enable --project $PROJECT \
     serviceusage.googleapis.com \
     stackdriver.googleapis.com \
     monitoring.googleapis.com \
-    logging.googleapis.com
+    logging.googleapis.com  \
+    anthosgke.googleapis.com
 
 
 
 
-
+#if selected, create the storage reader service account, key, and role binding
 if [ $STORAGE_OPTION = "y" ]; then
    gcloud iam service-accounts create storage-reader-service-account --project $STORAGE_PROJECT
    gcloud iam service-accounts keys create ./$FOLDER/storage-reader-key.json --iam-account  storage-reader-service-account@$STORAGE_PROJECT.iam.gserviceaccount.com


### PR DESCRIPTION
…readme

Some minor changes the create_service_accounts.sh to enable a new required api and add additional permissions to the whitelisted service account to fix some cosmetic errors when deploying a cluster.

Also some significant updates to the readme to  add more clarity. 