### PR TITLE
Cleaning up IPs!

### DIFF
--- a/08-esx-host-networking.tf
+++ b/08-esx-host-networking.tf
@@ -56,7 +56,7 @@ resource "null_resource" "apply_esx_network_config" {
   }
 
   provisioner "remote-exec" {
-    inline     = ["python3 /root/esx_host_networking.py --host '${element(packet_device.esxi_hosts.*.access_public_ipv4, count.index)}' --user root --pass '${element(packet_device.esxi_hosts.*.root_password, count.index)}' --id '${element(packet_device.esxi_hosts.*.id, count.index)}' --index ${count.index}"]
+    inline     = ["python3 /root/esx_host_networking.py --host '${element(packet_device.esxi_hosts.*.access_public_ipv4, count.index)}' --user root --pass '${element(packet_device.esxi_hosts.*.root_password, count.index)}' --id '${element(packet_device.esxi_hosts.*.id, count.index)}' --index ${count.index} --ipRes ${element(packet_reserved_ip_block.esx_ip_blocks.*.id, count.index)}"]
     on_failure = "continue"
 
   }

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -139,15 +139,16 @@ def connect_to_host(esx_host, esx_user, esx_pass):
 
 def main():
     parser = optparse.OptionParser(usage="%prog --host <host_ip> --user <username> --pass <password> "
-                                   "--vswitch <vswitch_name> --uplinks <comma_list_uplink_names>")
+                                   "--id <device_id> --index <terraform_index> --ipRes <ip_reservation>")
     parser.add_option('--host', dest="host", action="store", help="IP or FQDN of the ESXi host")
     parser.add_option('--user', dest="user", action="store", help="Username to authenticate to ESXi host")
     parser.add_option('--pass', dest="pw", action="store", help="Password to authenticarte to ESXi host")
     parser.add_option('--id', dest="id", action="store", help="Packet Device ID for Server")
     parser.add_option('--index', dest="index", action="store", help="Terraform index count, used for IPing")
+    parser.add_option('--ipRes', dest="ipRes", action="store", help="IP reservation for /29 ip block")
 
     options, _ = parser.parse_args()
-    if not (options.host and options.user and options.pw and options.id and options.index):
+    if not (options.host and options.user and options.pw and options.id and options.index and options.ipRes):
         print("ERROR: Missing arguments")
         parser.print_usage()
         sys.exit(1)
@@ -313,6 +314,8 @@ def main():
                         sys.exit(1)
                     print("Failed to add vLan to bond, trying again...")
                     sleep(5)
+    # Clean up IP Reservations
+    manager.delete_ip(options.ipRes)
 
 
 # Start program


### PR DESCRIPTION
I add the ability to clean up the ESXi IP reservation to save some money, as well as help not exhaust Packet IPs. This has been tested and a Terraform destroy does not care that these are deleted out of band.
fixes #15 