### PR TITLE
lock to packet provider 2.7.5

### DIFF
--- a/00-vars.tf
+++ b/00-vars.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    packet = "2.7.5"
+  }
+}
+
 variable "auth_token" {
 }
 


### PR DESCRIPTION
packet provider 2.8 may be causing problems with our networking. Locking to 2.7.5 until we can test fully