### PR TITLE
remove default variable for anthos version

### DIFF
--- a/30-anthos-vars.tf
+++ b/30-anthos-vars.tf
@@ -4,7 +4,6 @@ variable "anthos_gcp_project_id" {
 
 variable "anthos_version" {
   description = "Version of Google Anthos to install"
-  default     = "1.1.2-gke.0"
 }
 
 # Must be True or False (Case matters)


### PR DESCRIPTION
Let's ensure that users always declare the anthos version they wish to install by not including a default value for the  anthos_version variable.