### PR TITLE
gke on-prem release 1.3.0 updates

### DIFF
--- a/00-vars.tf
+++ b/00-vars.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    packet = "2.7.5"
+  }
+}
+
 variable "auth_token" {
 }
 
@@ -62,6 +68,10 @@ variable "public_subnets" {
       "ip_count" : 4
     }
   ]
+}
+
+variable "reserved_ip_space" {
+  default = 10
 }
 
 variable "router_hostname" {

--- a/00-vars.tf
+++ b/00-vars.tf
@@ -81,7 +81,7 @@ variable "esxi_size" {
 }
 
 variable "facility" {
-  default = "sjc1"
+  default = "dfw2"
 }
 
 variable "router_os" {

--- a/00-vars.tf
+++ b/00-vars.tf
@@ -81,7 +81,7 @@ variable "esxi_size" {
 }
 
 variable "facility" {
-  default = "dfw2"
+  default = "sjc1"
 }
 
 variable "router_os" {

--- a/00-vars.tf
+++ b/00-vars.tf
@@ -54,6 +54,7 @@ variable "private_subnets" {
       "vsphere_service_type" : null,
       "routable" : true,
       "cidr" : "172.16.3.0/24"
+      "reserved_ip_count" : 100
     }
   ]
 }
@@ -68,10 +69,6 @@ variable "public_subnets" {
       "ip_count" : 4
     }
   ]
-}
-
-variable "reserved_ip_count" {
-  default = 100
 }
 
 variable "router_hostname" {

--- a/00-vars.tf
+++ b/00-vars.tf
@@ -70,8 +70,8 @@ variable "public_subnets" {
   ]
 }
 
-variable "reserved_ip_space" {
-  default = 10
+variable "reserved_ip_count" {
+  default = 100
 }
 
 variable "router_hostname" {

--- a/03-edge-router.tf
+++ b/03-edge-router.tf
@@ -1,12 +1,12 @@
 data "template_file" "user_data" {
   template = file("templates/user_data.py")
   vars = {
-    private_subnets     = jsonencode(var.private_subnets)
-    private_vlans       = jsonencode(packet_vlan.private_vlans.*.vxlan)
-    public_subnets      = jsonencode(var.public_subnets)
-    public_vlans        = jsonencode(packet_vlan.public_vlans.*.vxlan)
-    public_cidrs        = jsonencode(packet_reserved_ip_block.ip_blocks.*.cidr_notation)
-    domain_name         = var.domain_name
+    private_subnets = jsonencode(var.private_subnets)
+    private_vlans   = jsonencode(packet_vlan.private_vlans.*.vxlan)
+    public_subnets  = jsonencode(var.public_subnets)
+    public_vlans    = jsonencode(packet_vlan.public_vlans.*.vxlan)
+    public_cidrs    = jsonencode(packet_reserved_ip_block.ip_blocks.*.cidr_notation)
+    domain_name     = var.domain_name
   }
 }
 

--- a/03-edge-router.tf
+++ b/03-edge-router.tf
@@ -1,12 +1,13 @@
 data "template_file" "user_data" {
   template = file("templates/user_data.py")
   vars = {
-    private_subnets = jsonencode(var.private_subnets)
-    private_vlans   = jsonencode(packet_vlan.private_vlans.*.vxlan)
-    public_subnets  = jsonencode(var.public_subnets)
-    public_vlans    = jsonencode(packet_vlan.public_vlans.*.vxlan)
-    public_cidrs    = jsonencode(packet_reserved_ip_block.ip_blocks.*.cidr_notation)
-    domain_name     = var.domain_name
+    private_subnets     = jsonencode(var.private_subnets)
+    private_vlans       = jsonencode(packet_vlan.private_vlans.*.vxlan)
+    public_subnets      = jsonencode(var.public_subnets)
+    public_vlans        = jsonencode(packet_vlan.public_vlans.*.vxlan)
+    public_cidrs        = jsonencode(packet_reserved_ip_block.ip_blocks.*.cidr_notation)
+    domain_name         = var.domain_name
+    reserved_ip_count = var.reserved_ip_count
   }
 }
 

--- a/03-edge-router.tf
+++ b/03-edge-router.tf
@@ -7,7 +7,6 @@ data "template_file" "user_data" {
     public_vlans        = jsonencode(packet_vlan.public_vlans.*.vxlan)
     public_cidrs        = jsonencode(packet_reserved_ip_block.ip_blocks.*.cidr_notation)
     domain_name         = var.domain_name
-    reserved_ip_count = var.reserved_ip_count
   }
 }
 

--- a/04-esx-hosts.tf
+++ b/04-esx-hosts.tf
@@ -8,7 +8,7 @@ resource "packet_device" "esxi_hosts" {
   billing_cycle    = var.billing_cycle
   project_id       = packet_project.new_project.id
   network_type     = "hybrid"
-  tags = ["vmware", "hypervisor", "anthos"]
+  tags             = ["vmware", "hypervisor", "anthos"]
   ip_address {
     type            = "public_ipv4"
     cidr            = 29

--- a/08-esx-host-networking.tf
+++ b/08-esx-host-networking.tf
@@ -45,7 +45,8 @@ resource "null_resource" "apply_esx_network_config" {
     packet_port_vlan_attachment.esxi_priv_vlan_attach,
     packet_port_vlan_attachment.esxi_pub_vlan_attach,
     null_resource.esx_network_prereqs,
-    null_resource.copy_update_uplinks
+    null_resource.copy_update_uplinks,
+    null_resource.install_vpn_server
   ]
 
   connection {

--- a/32-anthos-pre-reqs.tf
+++ b/32-anthos-pre-reqs.tf
@@ -3,6 +3,7 @@ data "template_file" "anthos_pre_reqs_script" {
   vars = {
     anthos_version       = var.anthos_version
     whitelisted_key_name = var.whitelisted_key_name
+    vcenter_fqdn         = format("vcva.%s", var.domain_name) 
   }
 }
 

--- a/32-anthos-pre-reqs.tf
+++ b/32-anthos-pre-reqs.tf
@@ -3,7 +3,7 @@ data "template_file" "anthos_pre_reqs_script" {
   vars = {
     anthos_version       = var.anthos_version
     whitelisted_key_name = var.whitelisted_key_name
-    vcenter_fqdn         = format("vcva.%s", var.domain_name) 
+    vcenter_fqdn         = format("vcva.%s", var.domain_name)
   }
 }
 

--- a/33-anthos-deploy-admin-workstation.tf
+++ b/33-anthos-deploy-admin-workstation.tf
@@ -1,9 +1,9 @@
 data "template_file" "anthos_workstation_tf_vars" {
   template = file("anthos/static-ip.tfvars")
   vars = {
-    vcenter_username      = "Administrator@vsphere.local"
-    vcenter_password      = random_string.sso_password.result
-    vcenter_fqdn          = format("vcva.%s", var.domain_name)
+    vcenter_username = "Administrator@vsphere.local"
+    vcenter_password = random_string.sso_password.result
+    vcenter_fqdn     = format("vcva.%s", var.domain_name)
 
     vsphere_datastore     = var.anthos_datastore
     vsphere_datacenter    = var.vcenter_datacenter_name
@@ -35,7 +35,7 @@ data "template_file" "anthos_replace_ws_vars" {
   }
 }
 
-data "template_file" "anthos_workstation_config_yaml"{
+data "template_file" "anthos_workstation_config_yaml" {
   template = file("anthos/admin-ws-config.yaml")
   vars = {
     vcenter_username      = "Administrator@vsphere.local"

--- a/33-anthos-deploy-admin-workstation.tf
+++ b/33-anthos-deploy-admin-workstation.tf
@@ -89,8 +89,8 @@ resource "null_resource" "anthos_deploy_workstation" {
   }
 
   provisioner "file" {
-    content     = data.template_file.anthos_workstation_config_yaml
-    destination = "/root/anthos/admin_ws_config.yaml"
+    content     = data.template_file.anthos_workstation_config_yaml.rendered
+    destination = "/root/anthos/admin-ws-config.yaml"
   }
 
   provisioner "file" {
@@ -103,7 +103,7 @@ resource "null_resource" "anthos_deploy_workstation" {
       "cd /root/anthos/",
       "chmod +x /root/anthos/upload_ova.sh",
       "/root/anthos/upload_ova.sh",
-      "python3 /root/anthos/replace_tf_vars.py",
+      "python3 /root/anthos/replace_ws_vars.py",
       "chmod +x /root/anthos/deploy_admin_ws.sh",
       "/root/anthos/deploy_admin_ws.sh"
     ]

--- a/33-anthos-deploy-admin-workstation.tf
+++ b/33-anthos-deploy-admin-workstation.tf
@@ -46,7 +46,15 @@ data "template_file" "anthos_workstation_config_yaml"{
     vsphere_cluster       = var.vcenter_cluster_name
     vsphere_resource_pool = var.anthos_resource_pool_name
     vsphere_network       = format("%s Net", var.vcenter_portgroup_name)
-    whitelisted_key_name  = var.whitelisted-key.json
+    whitelisted_key_name  = var.whitelisted_key_name
+  }
+}
+
+
+data "template_file" "anthos_deploy_admin_ws_sh" {
+  template = file("anthos/deploy_admin_ws.sh")
+  vars = {
+    vcenter_fqdn = format("vcva.%s", var.domain_name)
   }
 }
 
@@ -76,7 +84,7 @@ resource "null_resource" "anthos_deploy_workstation" {
   }
 
   provisioner "file" {
-    content     = data.template_file.anthos_replace_tf_vars.rendered
+    content     = data.template_file.anthos_replace_ws_vars.rendered
     destination = "/root/anthos/replace_ws_vars.py"
   }
 
@@ -86,7 +94,7 @@ resource "null_resource" "anthos_deploy_workstation" {
   }
 
   provisioner "file" {
-    content     = file("anthos/deploy_admin_ws.sh")
+    content     = data.template_file.anthos_deploy_admin_ws_sh.rendered
     destination = "/root/anthos/deploy_admin_ws.sh"
   }
 

--- a/34-anthos-deploy-clusters.tf
+++ b/34-anthos-deploy-clusters.tf
@@ -62,6 +62,7 @@ data "template_file" "anthos_cluster_creation_script" {
     vcenter_datacenter       = var.vcenter_datacenter_name
     whitelisted_key_name     = var.whitelisted_key_name
     anthos_user_cluster_name = var.anthos_user_cluster_name
+    esxi_host_count          = var.esxi_host_count
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ The Terrafrom has been succesfully tested with following versions of GKE on-prem
 * 1.2.0-gke.6*
 * 1.2.1-gke.4*
 * 1.2.2-gke.2*
-* 1.3.0-gke.16
+* 1.3.0-gke.16**
 
 To simplify setup, this is designed to used the EAP bundled Seesaw load balancer scheduled to go GA later this year. No other load balancer support is planned at this time.
 
 \*Due to a known bug in the EAP version, the script will automatically detect when using the EAP version and automatically delete the secondary LB in each group (admin and user cluster) to prevent the bug from occurring.
 
+\*\*This release appears to take 15-20 minutes longer to deploy. Some of that is due to the introduction of gkeadm to deploy the admin worksation. We are studying if there are any other possible optimizations that can be made to speed up the deployment.
 ## Setup your GCS object store 
 You will need a GCS  object store in order to download *closed source* packages such as *vCenter* and the *vSan SDK*. (See below for an S3 compatible object store option)
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ The Terrafrom has been succesfully tested with following versions of GKE on-prem
 * 1.2.0-gke.6*
 * 1.2.1-gke.4*
 * 1.2.2-gke.2*
-* 1.3.0-gke.16**
+* 1.3.0-gke.16
 
 To simplify setup, this is designed to used the EAP bundled Seesaw load balancer scheduled to go GA later this year. No other load balancer support is planned at this time.
 
 \*Due to a known bug in the EAP version, the script will automatically detect when using the EAP version and automatically delete the secondary LB in each group (admin and user cluster) to prevent the bug from occurring.
-
-\*\*1.3.0-gke.16 deploys as is currently. However it currently will only deploy a single LB and does not use the gkeadm process. We've opened two issues and are working to address this. ([Issue #18](https://github.com/packet-labs/google-anthos/issues/18), [Issue #35](https://github.com/packet-labs/google-anthos/issues/35) )
 
 ## Setup your GCS object store 
 You will need a GCS  object store in order to download *closed source* packages such as *vCenter* and the *vSan SDK*. (See below for an S3 compatible object store option)
@@ -137,7 +135,7 @@ project_name = "anthos-packet-project-1"
 anthos_gcp_project_id = "my-anthos-project" 
 gcs_bucket_name = "bucket_name/folder" 
 vcenter_iso_name = "VMware-VCSA-all-6.7.0-XXXXXXX.iso" 
-anthos_version = "1.2.2-gke.2"
+anthos_version = "1.3.0-gke.16"
 anthos_user_cluster_name = "packet-cluster-1"
 EOF 
 ``` 
@@ -181,7 +179,7 @@ s3_bucket_name = "vmware"
 s3_access_key = "4fa85962-975f-4650-b603-17f1cb9dee10" 
 s3_secret_key = "becf3868-3f07-4dbb-a6d5-eacfd7512b09" 
 vcenter_iso_name = "VMware-VCSA-all-6.7.0-XXXXXXX.iso" 
-anthos_version = "1.2.2-gke.2"
+anthos_version = "1.3.0-gke.16"
 anthos_user_cluster_name = "packet-cluster-1"
 EOF 
 ```  
@@ -239,7 +237,7 @@ You will need to ssh into the router/gateway and from there ssh into the admin w
 
 ```
 ssh root@VPN_Endpoint
-ssh -i /root/anthos/ssh_key ubuntu@172.16.0.3
+ssh -i /root/anthos/ssh_key ubuntu@admin_workstation
 ```
 
 The kubeconfig files for the admin and user clusters are located under ~/cluster, you can for example check the nodes of the admin cluster with the following command
@@ -247,6 +245,17 @@ The kubeconfig files for the admin and user clusters are located under ~/cluster
 ```
 kubectl --kubeconfig ~/cluster/kubeconfig get nodes
 ```
+
+## Exposing k8s services
+Currently services can be exposed on the bundled Seesaw load balancer(s) on VIPs
+within the VM Private Network (172.16.3.0/24 by default). By default we exclude
+the last 98 usable IPs of the 172.16.3.0/24 subnet from the DHCP range--
+172.16.3.156-172.16.3.54. You can
+change this number by adjusting the `reserved_ip_count` field in the VM Private
+Network json in `00-vars.tf`. 
+
+At this point services are not exposed to the public internet. One could adjust
+iptables on the edge-gateway to forward ports/IPs to VIP.
 
 ## Cleaning the environement
 To clean up a created environment (or a failed one), run `terraform destroy --auto-approve`.

--- a/anthos/admin-ws-config.yaml
+++ b/anthos/admin-ws-config.yaml
@@ -1,0 +1,46 @@
+gcp:
+  # Path of the whitelisted service account's JSON key file
+  whitelistedServiceAccountKeyPath: "/root/anthos/gcp_keys/${whitelisted_key_name}"
+# Specify which vCenter resources to use
+vCenter:i
+  # The credentials and address GKE On-Prem should use to connect to vCenter
+  credentials:
+    address: "${vcenter_fqdn}"
+    username: "${vcenter_user}"
+    password: "${vcenter_pass}"
+  datacenter: "${vcenter_datacenter}"
+  datastore: "${vcenter_datastore}"
+  cluster: "${vcenter_cluster}"
+  network: "${deploy_network}"
+  resourcepool: "${resource_pool}"
+  # Provide the path to vCenter CA certificate pub key for SSL verification
+  caCertPath: "/root/anthos/vspherecert.pem"
+# The URL of the proxy for the jump host
+proxyUrl: ""
+adminWorkstation:
+  name: admin-workstation
+  cpus: 4
+  memoryMB: 8192
+  # The disk size of the admin workstation in GB. It is recommended to use a disk
+  # with at least 50 GB to host images decompressed from the bundle.
+  diskGB: 50
+  network:
+    # The IP allocation mode: 'dhcp' or 'static'
+    ipAllocationMode: "static"
+    # # The host config in static IP mode. Do not include if using DHCP
+    hostConfig:
+       # The IPv4 static IP address for the admin workstation
+      ip: "__IP_ADDRESS__"
+       # The IP address of the default gateway of the subnet in which the admin workstation
+       # is to be created
+      gateway: "__GATEWAY__"
+       # The subnet mask of the network where you want to create your admin workstation
+      netmask: "__NETMASK__"
+       # The list of DNS nameservers to be used by the admin workstation
+      dns:
+       - "__GATEWAY__"
+       - "8.8.8.8"
+       - "8.8.4.4"
+  # The URL of the proxy for the admin workstation
+  proxyUrl: ""
+  ntpServer: ntp.ubuntu.com

--- a/anthos/admin-ws-config.yaml
+++ b/anthos/admin-ws-config.yaml
@@ -6,13 +6,13 @@ vCenter:i
   # The credentials and address GKE On-Prem should use to connect to vCenter
   credentials:
     address: "${vcenter_fqdn}"
-    username: "${vcenter_user}"
-    password: "${vcenter_pass}"
-  datacenter: "${vcenter_datacenter}"
-  datastore: "${vcenter_datastore}"
-  cluster: "${vcenter_cluster}"
-  network: "${deploy_network}"
-  resourcepool: "${resource_pool}"
+    username: "${vcenter_username}"
+    password: "${vcenter_password}"
+  datacenter: "${vsphere_datacenter}"
+  datastore: "${vsphere_datastore}"
+  cluster: "${vsphere_cluster}"
+  network: "${vpshere_network}"
+  resourcepool: "${vsphere_resource_pool}"
   # Provide the path to vCenter CA certificate pub key for SSL verification
   caCertPath: "/root/anthos/vspherecert.pem"
 # The URL of the proxy for the jump host

--- a/anthos/admin-ws-config.yaml
+++ b/anthos/admin-ws-config.yaml
@@ -2,7 +2,7 @@ gcp:
   # Path of the whitelisted service account's JSON key file
   whitelistedServiceAccountKeyPath: "/root/anthos/gcp_keys/${whitelisted_key_name}"
 # Specify which vCenter resources to use
-vCenter:i
+vCenter:
   # The credentials and address GKE On-Prem should use to connect to vCenter
   credentials:
     address: "${vcenter_fqdn}"
@@ -11,7 +11,7 @@ vCenter:i
   datacenter: "${vsphere_datacenter}"
   datastore: "${vsphere_datastore}"
   cluster: "${vsphere_cluster}"
-  network: "${vpshere_network}"
+  network: "${vsphere_network}"
   resourcepool: "${vsphere_resource_pool}"
   # Provide the path to vCenter CA certificate pub key for SSL verification
   caCertPath: "/root/anthos/vspherecert.pem"

--- a/anthos/cluster/bundled-lb-admin-uc1-config.yaml
+++ b/anthos/cluster/bundled-lb-admin-uc1-config.yaml
@@ -28,6 +28,7 @@ admincluster:
     vip: __ADMIN_LB_VIP__
     cpus: 4
     memorymb: 8192
+    #Xenableha: true
     antiaffinitygroups:
       enabled: false
   vips:
@@ -53,8 +54,9 @@ usercluster:
     vip: __USER_LB_VIP__
     cpus: 4
     memorymb: 8192
+    #Xenable: true
     antiaffinitygroups:
-      enabled: false  
+      enabled: false
   vips:
     # Used to connect to the Kubernetes API
     controlplanevip: "__USER_K8S_API_VIP__"

--- a/anthos/cluster/bundled-lb-admin-uc1-config.yaml
+++ b/anthos/cluster/bundled-lb-admin-uc1-config.yaml
@@ -54,7 +54,7 @@ usercluster:
     vip: __USER_LB_VIP__
     cpus: 4
     memorymb: 8192
-    #Xenable: true
+    #Xenableha: true
     antiaffinitygroups:
       enabled: false
   vips:

--- a/anthos/cluster/bundled-lb-install-script.sh
+++ b/anthos/cluster/bundled-lb-install-script.sh
@@ -17,14 +17,14 @@ openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null |
 if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
   export SYLLOGI_FEATURE_GATES="EnableBundledLB=true"
 else
-  sed -i 's/#X//g/' /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml
   if (( "$ESXICOUNT" > "1" )) ; then
     sed -i 's/enabled: false/enabled: true/' bundled-lb-admin-uc1-config.yaml
+    sed -i 's/#X//g' /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml
   fi
 fi
 
 
-gkectl check-config --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml
+gkectl check-config --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml --fast
 gkectl prepare --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml  --skip-validation-all
 gkectl create loadbalancer --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml  --skip-validation-all
 

--- a/anthos/cluster/bundled-lb-install-script.sh
+++ b/anthos/cluster/bundled-lb-install-script.sh
@@ -18,11 +18,11 @@ if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
   export SYLLOGI_FEATURE_GATES="EnableBundledLB=true"
 else
   sed -i 's/#X//g/' /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml
+  if (( "$ESXICOUNT" > "1" )) ; then
+    sed -i 's/enabled: false/enabled: true/' bundled-lb-admin-uc1-config.yaml
+  fi
 fi
 
-if (( "$ESXICOUNT" > "1" )) ; then
-  sed -i 's/enabled: false/enabled: true/' bundled-lb-admin-uc1-config.yaml
-fi
 
 gkectl check-config --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml
 gkectl prepare --config /home/ubuntu/cluster/bundled-lb-admin-uc1-config.yaml  --skip-validation-all

--- a/anthos/cluster/bundled-lb-install-script.sh
+++ b/anthos/cluster/bundled-lb-install-script.sh
@@ -5,7 +5,7 @@ export GOVC_USERNAME='${vcenter_user}'
 export GOVC_PASSWORD='${vcenter_pass}'
 export GOVC_INSECURE=true
 VERSION=$(gkectl version | awk '{print $2}')
-ESXICOUNT='${esxi_host_count}
+ESXICOUNT='${esxi_host_count}'
 
 govc datastore.mkdir -dc="${vcenter_datacenter}" -ds="${vcenter_datastore}" gke-on-prem/
 

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -4,9 +4,10 @@
 
 if [ -f "/root/anthos/gkeadm" ] ; then
   echo "Deploying Admin Workstation with gkeadm"
+  openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
   /root/anthos/gkeadm --config admin-ws-config.yaml
 else
-  echo "Deploying Admin workstation with terraform"
+  echo "Deploying Admin Workstation with terraform"
   terraform init
   terraform apply --auto-approve
 fi

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -6,11 +6,8 @@ if [ -f "/root/anthos/gkeadm" ] ; then
   echo "Deploying Admin Workstation with gkeadm"
   openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
   /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml
-  
-  export KEY=$(cat /root/anthos/ssh_key.pub)
-  
-  ssh -i /root/.ssh/gke-admin-workstation ubuntu@$WORKSTATIONIP 'echo "$KEY" >> /home/ubuntu/.ssh/authorized_keys'
-
+  scp -i /root/.ssh/gke-admin-workstation /root/anthos/ssh_key.pub ubuntu@$WORKSTATIONIP:/home/ubuntu/.ssh/  
+  ssh -i /root/.ssh/gke-admin-workstation ubuntu@$WORKSTATIONIP 'echo "$(cat /home/ubuntu/.ssh/ssh_key.pub)" >> /home/ubuntu/.ssh/authorized_keys'
 else
   echo "Deploying Admin Workstation with terraform"
   terraform init

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-
+export WORKSTATIONIP=__IP_ADDRESS__
 
 if [ -f "/root/anthos/gkeadm" ] ; then
   echo "Deploying Admin Workstation with gkeadm"
   openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
-  /root/anthos/gkeadm --config admin-ws-config.yaml
+  /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml
+  
+  export KEY=$(cat /root/anthos/ssh_key.pub)
+  
+  ssh -i /root/.ssh/gke-admin-workstation ubuntu@$WORKSTATIONIP 'echo "$KEY" >> /home/ubuntu/.ssh/authorized_keys'
+
 else
   echo "Deploying Admin Workstation with terraform"
   terraform init

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -6,7 +6,7 @@ if [ -f "/root/anthos/gkeadm" ] ; then
   echo "Deploying Admin Workstation with gkeadm"
   openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
   /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml
-  scp -i /root/.ssh/gke-admin-workstation /root/anthos/ssh_key.pub ubuntu@$WORKSTATIONIP:/home/ubuntu/.ssh/  
+  scp -i /root/.ssh/gke-admin-workstation /root/anthos/ssh_key.pub ubuntu@$WORKSTATIONIP:/home/ubuntu/.ssh/ssh_key.pub
   ssh -i /root/.ssh/gke-admin-workstation ubuntu@$WORKSTATIONIP 'echo "$(cat /home/ubuntu/.ssh/ssh_key.pub)" >> /home/ubuntu/.ssh/authorized_keys'
 else
   echo "Deploying Admin Workstation with terraform"

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -5,9 +5,7 @@ export WORKSTATIONIP=__IP_ADDRESS__
 if [ -f "/root/anthos/gkeadm" ] ; then
   echo "Deploying Admin Workstation with gkeadm"
   openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
-  /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml
-  scp -i /root/.ssh/gke-admin-workstation /root/anthos/ssh_key.pub ubuntu@$WORKSTATIONIP:/home/ubuntu/.ssh/ssh_key.pub
-  ssh -i /root/.ssh/gke-admin-workstation ubuntu@$WORKSTATIONIP 'echo "$(cat /home/ubuntu/.ssh/ssh_key.pub)" >> /home/ubuntu/.ssh/authorized_keys'
+  /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml --ssh-key-path /root/anthos/ssh_key
 else
   echo "Deploying Admin Workstation with terraform"
   terraform init

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+
+if [ -f "/root/anthos/gkeadm" ] ; then
+  echo "Deploying Admin Workstation with gkeadm"
+  /root/anthos/gkeadm --config admin-ws-config.yaml
+else
+  echo "Deploying Admin workstation with terraform"
+  terraform init
+  terraform apply --auto-approve
+fi

--- a/anthos/pre_reqs.sh
+++ b/anthos/pre_reqs.sh
@@ -4,6 +4,7 @@ export VERSION='${anthos_version}'
 
 cd /root/anthos
 
+
 # Install GoVC
 wget https://github.com/vmware/govmomi/releases/download/v0.21.0/govc_linux_amd64.gz
 gzip -d govc_linux_amd64.gz
@@ -18,7 +19,15 @@ chmod +x terraform
 mv terraform /usr/local/bin
 rm -f terraform_0.12.18_linux_amd64.zip
 
-# Download and deploy admin workstation
+# Download and admin workstation
 gcloud auth activate-service-account --key-file=$HOME/anthos/gcp_keys/${whitelisted_key_name}
-gsutil cp gs://gke-on-prem-release/admin-appliance/$VERSION/gke-on-prem-admin-appliance-vsphere-$VERSION.ova ~/anthos/
 
+openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="~/anthos/vspherecert.pem"; print >out}'
+
+# Download and admin workstation or gkeadm
+if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
+  gsutil cp gs://gke-on-prem-release/admin-appliance/$VERSION/gke-on-prem-admin-appliance-vsphere-$VERSION.ova ~/anthos/
+else
+  gsutil cp gs://gke-on-prem-release/gkeadm/$VERSION/linux/gkeadm /root/anthos/
+  chmod +x /root/anthos/gkeadm
+end

--- a/anthos/pre_reqs.sh
+++ b/anthos/pre_reqs.sh
@@ -22,7 +22,6 @@ rm -f terraform_0.12.18_linux_amd64.zip
 # Download and admin workstation
 gcloud auth activate-service-account --key-file=$HOME/anthos/gcp_keys/${whitelisted_key_name}
 
-openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="~/anthos/vspherecert.pem"; print >out}'
 
 # Download and admin workstation or gkeadm
 if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
@@ -30,4 +29,4 @@ if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
 else
   gsutil cp gs://gke-on-prem-release/gkeadm/$VERSION/linux/gkeadm /root/anthos/
   chmod +x /root/anthos/gkeadm
-end
+fi

--- a/anthos/replace_ws_vars.py
+++ b/anthos/replace_ws_vars.py
@@ -16,6 +16,7 @@ for subnet in subnets:
         gateway_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         prefix_length = int(subnet['cidr'].split('/')[1])
         netmask =  ipaddress.netmask('cidr')
+        print (netmask)
 
 os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/terraform.tfvars".format(workstation_ip))
 os.system("sed -i 's/__IP_PREFIX_LENGTH__/{}/g' /root/anthos/terraform.tfvars".format(prefix_length))

--- a/anthos/replace_ws_vars.py
+++ b/anthos/replace_ws_vars.py
@@ -15,10 +15,15 @@ for subnet in subnets:
         workstation_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[2].compressed
         gateway_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         prefix_length = int(subnet['cidr'].split('/')[1])
+        netmask =  ipaddress.netmask('cidr')
 
 os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/terraform.tfvars".format(workstation_ip))
 os.system("sed -i 's/__IP_PREFIX_LENGTH__/{}/g' /root/anthos/terraform.tfvars".format(prefix_length))
 os.system("sed -i 's/__GATEWAY__/{}/g' /root/anthos/terraform.tfvars".format(gateway_ip))
+
+os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/admin-ws-config.yaml".format(workstation_ip))
+os.system("sed -i 's/__NETMASK__/{}/g' /root/anthos/admin-ws-config.yaml".format(prefix_length))
+os.system("sed -i 's/__GATEWAY__/{}/g' /root/anthos/admin-ws-config.yaml".format(gateway_ip))
 
 # Reserve IP in dnsmasq
 dnsmasq_conf = open('/etc/dnsmasq.d/dhcp.conf', 'a+')

--- a/anthos/replace_ws_vars.py
+++ b/anthos/replace_ws_vars.py
@@ -15,16 +15,17 @@ for subnet in subnets:
         workstation_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[2].compressed
         gateway_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         prefix_length = int(subnet['cidr'].split('/')[1])
-        netmask =  ipaddress.netmask('cidr')
-        print (netmask)
+        network = ipaddress.IPv4Network(subnet['cidr'], strict=True)
+        netmask =  network.netmask
 
 os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/terraform.tfvars".format(workstation_ip))
 os.system("sed -i 's/__IP_PREFIX_LENGTH__/{}/g' /root/anthos/terraform.tfvars".format(prefix_length))
 os.system("sed -i 's/__GATEWAY__/{}/g' /root/anthos/terraform.tfvars".format(gateway_ip))
 
 os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/admin-ws-config.yaml".format(workstation_ip))
-os.system("sed -i 's/__NETMASK__/{}/g' /root/anthos/admin-ws-config.yaml".format(prefix_length))
+os.system("sed -i 's/__NETMASK__/{}/g' /root/anthos/admin-ws-config.yaml".format(netmask))
 os.system("sed -i 's/__GATEWAY__/{}/g' /root/anthos/admin-ws-config.yaml".format(gateway_ip))
+os.system("sed -i 's/__IP_ADDRESS__/{}/g' /root/anthos/deploy_admin_ws.sh".format(workstation_ip))
 
 # Reserve IP in dnsmasq
 dnsmasq_conf = open('/etc/dnsmasq.d/dhcp.conf', 'a+')

--- a/anthos/upload_ova.sh
+++ b/anthos/upload_ova.sh
@@ -7,6 +7,10 @@ export GOVC_PASSWORD='${vmware_password}'
 export GOVC_DATASTORE='${vmware_datastore}'
 export GOVC_INSECURE=true
 
-govc import.ova ~/anthos/gke-on-prem-admin-appliance-vsphere-$VERSION.ova
-govc vm.markastemplate gke-on-prem-admin-appliance-vsphere-$VERSION
+
+if [ ! -f "/root/anthos/gkeadm" ] ; then
+  govc import.ova ~/anthos/gke-on-prem-admin-appliance-vsphere-$VERSION.ova
+  govc vm.markastemplate gke-on-prem-admin-appliance-vsphere-$VERSION
+fi
+
 govc pool.create '*/${vmware_resource_pool}'

--- a/templates/user_data.py
+++ b/templates/user_data.py
@@ -13,7 +13,6 @@ public_subnets = '${public_subnets}'
 public_vlans = '${public_vlans}'
 public_cidrs = '${public_cidrs}'
 domain_name = '${domain_name}'
-reserved_ip_count = '${reserved_ip_count}'
 
 def words_list():
     word_site = "https://raw.githubusercontent.com/taikuukaits/SimpleWordlists/master/Wordlist-Nouns-Common-Audited-Len-3-6.txt"
@@ -112,7 +111,11 @@ for subnet in subnets:
         # Gather network facts about this subnet
         router_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         low_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
-        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-reserved_ip_count].compressed
+        if 'reserved_ip_count' in subnet:
+          high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-subnet['reserved_ip_count']].compressed
+        else:
+          high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-1].compressed
+
         netmask = ipaddress.ip_network(subnet['cidr']).netmask.compressed
 
         # Setup vLan interface for this subnet

--- a/templates/user_data.py
+++ b/templates/user_data.py
@@ -13,7 +13,7 @@ public_subnets = '${public_subnets}'
 public_vlans = '${public_vlans}'
 public_cidrs = '${public_cidrs}'
 domain_name = '${domain_name}'
-reserved_ip_space = '${reserved_ip_space}'
+reserved_ip_count = '${reserved_ip_count}'
 
 def words_list():
     word_site = "https://raw.githubusercontent.com/taikuukaits/SimpleWordlists/master/Wordlist-Nouns-Common-Audited-Len-3-6.txt"
@@ -112,7 +112,7 @@ for subnet in subnets:
         # Gather network facts about this subnet
         router_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         low_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
-        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-reserved_ip_space].compressed
+        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-reserved_ip_count].compressed
         netmask = ipaddress.ip_network(subnet['cidr']).netmask.compressed
 
         # Setup vLan interface for this subnet

--- a/templates/user_data.py
+++ b/templates/user_data.py
@@ -13,7 +13,7 @@ public_subnets = '${public_subnets}'
 public_vlans = '${public_vlans}'
 public_cidrs = '${public_cidrs}'
 domain_name = '${domain_name}'
-
+reserved_ip_space = '${reserved_ip_space}'
 
 def words_list():
     word_site = "https://raw.githubusercontent.com/taikuukaits/SimpleWordlists/master/Wordlist-Nouns-Common-Audited-Len-3-6.txt"
@@ -112,7 +112,7 @@ for subnet in subnets:
         # Gather network facts about this subnet
         router_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         low_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
-        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-100].compressed
+        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-reserved_ip_space].compressed
         netmask = ipaddress.ip_network(subnet['cidr']).netmask.compressed
 
         # Setup vLan interface for this subnet

--- a/templates/user_data.py
+++ b/templates/user_data.py
@@ -112,7 +112,7 @@ for subnet in subnets:
         # Gather network facts about this subnet
         router_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
         low_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
-        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-1].compressed
+        high_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[-100].compressed
         netmask = ipaddress.ip_network(subnet['cidr']).netmask.compressed
 
         # Setup vLan interface for this subnet


### PR DESCRIPTION
Major changes include:

- using gkeadm to deploy admin workstation for versions 1.3 and later. Versions 1.1 and 1.2 will use terraform method still (introduced deploy-admin-ws.sh script for this purpose).
- Enable HA load balancers and anti-affinity mode when using 2 or more ESXi servers and version 1.3 or later.
- limit DHCP range (100 IPs by default) to be used for services VIPs


Minor changes include:
- Setting packet terraform to 2.7.5 until 2.8.0 can be further tested
- Updated readme with support for 1.3.0-gke.16 information
- Updated readme ssh to admin workstation with the host name admin-workstation instead of the IP
- Made ESXi networking update depend on vpn server being finished for stability
- Renamed replace_tf_vars.py → replace_ws_vars.py to represent the changes to gkeadm

I've tested this already with 1.2 and 1.3 with 1 esxi host as well as 3 esxi hosts (4 total scenarios) several times. 

resolves #37, resolves #35, resolves  #18  