### PR TITLE
improve output of create_service_accounts.sh

### DIFF
--- a/anthos/create_service_accounts.sh
+++ b/anthos/create_service_accounts.sh
@@ -2,14 +2,15 @@
 
 
 #start the interactive portion to capture user details
-echo "This script will help you perform the setps outlined at https://cloud.google.com/gke-on-prem/docs/how-to/service-accounts \nYou will be provided the option to create a storage reader service account as well. \n\n"
-echo "Enter the name of the email of your whitelisted service account \n (example: whitelisted@my-anthos-project.iam.gserviceaccount.com):"
-read WL_SA_EMAIL
-echo "Create storage reader account? (y/n)"
-read STORAGE_OPTION
+echo "This script will help you perform the steps outlined at
+https://cloud.google.com/gke-on-prem/docs/how-to/service-accounts
+You will be provided the option to create a storage reader service account as well.
+
+Enter the name of the email of your whitelisted service account"
+read -p "(example: whitelisted@my-anthos-project.iam.gserviceaccount.com):" WL_SA_EMAIL
+read -p "Create storage reader account? (y/n)" STORAGE_OPTION
 if [ $STORAGE_OPTION = "y" ]; then
-    echo "Provide Project where GCS Bucket Lives"
-    read STORAGE_PROJECT
+    read -p "Provide Project where GCS Bucket Lives:" STORAGE_PROJECT
 fi
 
 


### PR DESCRIPTION
* fix typo "setps" --> steps.
* replace literal backslash-n sequences with actual newline chars since bash isn't interpreting the backslash-n as intended
* use read -p PROMPT so that the prompt will appear on the same line as the user is expected to type, instead of the next line.

these changes improve the readability of the output.