### PR TITLE
improve error handling in deploy_admin_ws.sh

### DIFF
--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -7,11 +7,43 @@ function note() {
 
 # print the given command to stderr, run it, and exit verbosely if it fails.
 function xrun() {
-  note "+ $@"
-  "$@" && return 0
+  vrun "$@" && return 0
+
   local xstat=$?
   note "Cmd $1 failed, exit $xstat"
   exit "$xstat"
+}
+
+# print the given command to stderr, run it.  return the status
+function vrun() {
+  note "+ $@"
+  "$@"
+}
+
+# fetch the vcenter pem from the givem host:port, and print it to stdout.
+function fetch_pem() {
+djfong@djfong-macbookair2$ cat !$
+cat deploy_admin_ws.sh
+#!/bin/bash
+
+# print a message to stderr, prefixed by HOSTNAME
+function note() {
+  echo 1>&2 "$HOSTNAME: $*"
+}
+
+# print the given command to stderr, run it, and exit verbosely if it fails.
+function xrun() {
+  vrun "$@" && return 0
+
+  local xstat=$?
+  note "Cmd $1 failed, exit $xstat"
+  exit "$xstat"
+}
+
+# print the given command to stderr, run it.  return the status
+function vrun() {
+  note "+ $@"
+  "$@"
 }
 
 # fetch the vcenter pem from the givem host:port, and print it to stdout.
@@ -35,7 +67,7 @@ if [ -f "/root/anthos/gkeadm" ] ; then
   echo "** IAM roles are expected and can safely be ignored                      **"
   echo "***********************#***************************************************"
   fetch_pem ${vcenter_fqdn}:443 > /root/anthos/vspherecert.pem || exit 1
-  xrun /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml --ssh-key-path /root/anthos/ssh_key --skip-validation
+  vrun /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml --ssh-key-path /root/anthos/ssh_key --skip-validation
   echo "*************************************************************************"
   echo "** Errors in the above section related to enabling APIs and creating   **"
   echo "** IAM roles are expected and can safely be ignored                    **"

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# print a message to stderr, prefixed by HOSTNAME
+# print a message to stderr, prefixed by the hostname
 function note() {
-  echo 1>&2 "$HOSTNAME: $*"
+  echo 1>&2 "$(hostname): $*"
 }
 
 # print the given command to stderr, run it, and exit verbosely if it fails.
@@ -29,8 +29,6 @@ function fetch_pem() {
 }
 
 # ----- statt of mainline code
-
-HOSTNAME=$(hostname)
 
 export WORKSTATIONIP=__IP_ADDRESS__
 

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
 
+# print a message to stderr, prefixed by HOSTNAME
+function note() {
+  echo 1>&2 "$HOSTNAME: $*"
+}
+
+# print the given command to stderr, run it, and exit verbosely if it fails.
+function xrun() {
+  note "+ $@"
+  "$@" && return 0
+  local xstat=$?
+  note "Cmd $1 failed, exit $xstat"
+  exit "$xstat"
+}
+
+# fetch the vcenter pem from the givem host:port, and print it to stdout.
+function fetch_pem() {
+  local addr=$1
+  xrun openssl s_client -showcerts -verify 5 -connect "$addr" < /dev/null \
+  | awk '/BEGIN/,/END/ {print}'
+  return "$((PIPESTATUS[0]))"
+}
+
+# ----- statt of mainline code
+
+HOSTNAME=$(hostname)
+
 export WORKSTATIONIP=__IP_ADDRESS__
 
 if [ -f "/root/anthos/gkeadm" ] ; then
@@ -8,14 +34,16 @@ if [ -f "/root/anthos/gkeadm" ] ; then
   echo "** Errors in the following section related to enabling APIs and creating **"
   echo "** IAM roles are expected and can safely be ignored                      **"
   echo "***********************#***************************************************"
-  openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'
-  /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml --ssh-key-path /root/anthos/ssh_key --skip-validation
+  fetch_pem ${vcenter_fqdn}:443 > /root/anthos/vspherecert.pem || exit 1
+  xrun /root/anthos/gkeadm create admin-workstation --config /root/anthos/admin-ws-config.yaml --ssh-key-path /root/anthos/ssh_key --skip-validation
   echo "*************************************************************************"
   echo "** Errors in the above section related to enabling APIs and creating   **"
   echo "** IAM roles are expected and can safely be ignored                    **"
   echo "*************************************************************************"
 else
   echo "Deploying Admin Workstation with terraform"
-  terraform init
-  terraform apply --auto-approve
+  xrun terraform init
+  xrun terraform apply --auto-approve
 fi
+
+note "# succeeded"

--- a/anthos/deploy_admin_ws.sh
+++ b/anthos/deploy_admin_ws.sh
@@ -22,32 +22,6 @@ function vrun() {
 
 # fetch the vcenter pem from the givem host:port, and print it to stdout.
 function fetch_pem() {
-djfong@djfong-macbookair2$ cat !$
-cat deploy_admin_ws.sh
-#!/bin/bash
-
-# print a message to stderr, prefixed by HOSTNAME
-function note() {
-  echo 1>&2 "$HOSTNAME: $*"
-}
-
-# print the given command to stderr, run it, and exit verbosely if it fails.
-function xrun() {
-  vrun "$@" && return 0
-
-  local xstat=$?
-  note "Cmd $1 failed, exit $xstat"
-  exit "$xstat"
-}
-
-# print the given command to stderr, run it.  return the status
-function vrun() {
-  note "+ $@"
-  "$@"
-}
-
-# fetch the vcenter pem from the givem host:port, and print it to stdout.
-function fetch_pem() {
   local addr=$1
   xrun openssl s_client -showcerts -verify 5 -connect "$addr" < /dev/null \
   | awk '/BEGIN/,/END/ {print}'


### PR DESCRIPTION
* major commands are printed to stderr before running.
* and will exit if on failure
* minor refactoring of complex pipelines
* i changed an awk command that i don't understand.  was:

    awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="/root/anthos/vspherecert.pem"; print >out}'

the "if(/BEGIN/) {a++};" seemed pointless, so i got rid of it.
also it is easier to redirect the printout externally to awk, so i did that.

my version:

    awk '/BEGIN/,/END/ {print}'