### PR TITLE
Pump Packet Provider Version

### DIFF
--- a/00-vars.tf
+++ b/00-vars.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    packet = "2.10.1"
+    packet = "~> 2.10.1"
   }
 }
 

--- a/00-vars.tf
+++ b/00-vars.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    packet = "2.7.5"
+    packet = "2.10.1"
   }
 }
 


### PR DESCRIPTION
I have fully tested and validated that the packet provider for 2.10.1 is working and we should bump up to this version. 