### PR TITLE
improve error handling in bundled-lb-install-script.sh

### DIFF
--- a/anthos/cluster/bundled-lb-install-script.sh
+++ b/anthos/cluster/bundled-lb-install-script.sh
@@ -1,12 +1,42 @@
 #!/bin/bash
+
+# print a message to stderr, prefixed by HOSTNAME
+function note() {
+  echo 1>&2 "$HOSTNAME: $*"
+}
+
+# print the given command to stderr, run it, and exit verbosely if it fails.
+function xrun() {
+  note "+ $@"
+  "$@" && return 0
+  local xstat=$?
+  note "Cmd $1 failed, exit $xstat"
+  exit "$xstat"
+}
+
+# fetch the pem from the given address, and print to stdout.
+fetch_pem() {
+  local addr=$1
+  xrun openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null \
+  | awk '/BEGIN/,/END/ {print}'
+  return "$((PIPESTATUS[0]))"
+}
+
+# ----- start of mainline code
+
+PROGNAME=bundled-lb-install-script.sh
+HOSTNAME=$(hostname)
+
 FILEPATH=/home/ubuntu/cluster/
 CONFIG=bundled-lb-admin-uc1-config.yaml
 ADCONFIG=admin-cluster-config.yaml
 USERCONFIG=user-cluster1-config.yaml
 ADKUBECONFIG=kubeconfig
 
+note "# Begin $PROGNAME"
 
-cd $FILEPATH
+
+cd $FILEPATH || exit 1
 export GOVC_URL='https://${vcenter_fqdn}/sdk'
 export GOVC_USERNAME='${vcenter_user}'
 export GOVC_PASSWORD='${vcenter_pass}'
@@ -14,12 +44,12 @@ export GOVC_INSECURE=true
 VERSION=$(gkectl version | awk '{print $2}')
 ESXICOUNT='${esxi_host_count}'
 
-govc datastore.mkdir -dc="${vcenter_datacenter}" -ds="${vcenter_datastore}" gke-on-prem/
+xrun govc datastore.mkdir -dc="${vcenter_datacenter}" -ds="${vcenter_datastore}" gke-on-prem/
 
-gcloud auth activate-service-account --key-file=/home/ubuntu/cluster/${whitelisted_key_name}
-gcloud auth configure-docker --quiet
+xrun gcloud auth activate-service-account --key-file=/home/ubuntu/cluster/${whitelisted_key_name}
+xrun gcloud auth configure-docker --quiet
 
-openssl s_client -showcerts -verify 5 -connect ${vcenter_fqdn}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="vspherecert.pem"; print >out}'
+fetch_pem ${vcenter_fqdn}:443 > vspherecert.pem
 
 if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
   export SYLLOGI_FEATURE_GATES="EnableBundledLB=true"
@@ -36,9 +66,9 @@ fi
 
 
 if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] || [[ "$VERSION" == 1.3* ]]; then
-  gkectl check-config --config $FILEPATH$CONFIG --fast
-  gkectl prepare --config $FILEPATH$CONFIG  --skip-validation-all
-  gkectl create loadbalancer --config $FILEPATH$CONFIG --skip-validation-all
+  xrun gkectl check-config --config $FILEPATH$CONFIG --fast
+  xrun gkectl prepare --config $FILEPATH$CONFIG  --skip-validation-all
+  xrun gkectl create loadbalancer --config $FILEPATH$CONFIG --skip-validation-all
 
   if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] ; then
     echo "EAP version of bundled LB detected, deleting redundant LBs"
@@ -48,14 +78,15 @@ if [[ "$VERSION" == 1.1* ]] || [[ "$VERSION" == 1.2* ]] || [[ "$VERSION" == 1.3*
     govc vm.destroy $VM2
   fi
 
-  gkectl create cluster --config $FILEPATH$CONFIG --skip-validation-all
+  xrun gkectl create cluster --config $FILEPATH$CONFIG --skip-validation-all
 else
-  gkectl check-config --config $FILEPATH$ADCONFIG --fast
-  gkectl prepare --config $FILEPATH$ADCONFIG --skip-validation-all
-  gkectl create loadbalancer --config $FILEPATH$ADCONFIG --skip-validation-all
-  gkectl create admin --config $FILEPATH$ADCONFIG --skip-validation-all
-  gkectl check-config --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG
-  gkectl create loadbalancer --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG --skip-validation-all
-  gkectl create cluster --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG --skip-validation-all
+  xrun gkectl check-config --config $FILEPATH$ADCONFIG --fast
+  xrun gkectl prepare --config $FILEPATH$ADCONFIG --skip-validation-all
+  xrun gkectl create loadbalancer --config $FILEPATH$ADCONFIG --skip-validation-all
+  xrun gkectl create admin --config $FILEPATH$ADCONFIG --skip-validation-all
+  xrun gkectl check-config --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG
+  xrun gkectl create loadbalancer --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG --skip-validation-all
+  xrun gkectl create cluster --config $FILEPATH$USERCONFIG  --kubeconfig $FILEPATH$ADKUBECONFIG --skip-validation-all
 fi
 
+note "# End $PROGNAME - success"


### PR DESCRIPTION
* major commands get echoed to stderr before executing, and will exit the script on failure.
* change to awk command - eliminate seemingly unnecessary if statement.

(similar to pending changes in deploy_admin_ws.sh, so the same issues could apply.)