### PR TITLE
prevent TF 0.12 warning by updating syntax

### DIFF
--- a/anthos/cluster/deploy_cluster.tf.tpl
+++ b/anthos/cluster/deploy_cluster.tf.tpl
@@ -1,33 +1,33 @@
 variable "admin_workstation_ip" {
 }
 
-resource "null_resource" "anthos_deploy_cluster" { 
-    connection { 
-        type = "ssh" 
-        user = "ubuntu" 
-        private_key = "${file("/root/anthos/ssh_key")}" 
-        host = "${var.admin_workstation_ip}" 
-    }
+resource "null_resource" "anthos_deploy_cluster" {
+  connection {
+    type        = "ssh"
+    user        = "ubuntu"
+    private_key = file("/root/anthos/ssh_key")
+    host        = "${var.admin_workstation_ip}"
+  }
 
-    provisioner "file" {
-        source      = "/root/anthos/cluster"
-        destination = "/home/ubuntu"
-    }
+  provisioner "file" {
+    source      = "/root/anthos/cluster"
+    destination = "/home/ubuntu"
+  }
 
-    provisioner "remote-exec" { 
-        inline = [
-            "cd /home/ubuntu/cluster/",
-            "bash /home/ubuntu/cluster/bundled-lb-install-script.sh",
-            "bash /home/ubuntu/cluster/finish_cluster.sh"
-        ]   
-    }  
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/ubuntu/cluster/",
+      "bash /home/ubuntu/cluster/bundled-lb-install-script.sh",
+      "bash /home/ubuntu/cluster/finish_cluster.sh"
+    ]
+  }
 
 }
 
 
-resource "null_resource" "anthos_copy_token"{
-     depends_on = [null_resource.anthos_deploy_cluster]
-     provisioner "local-exec" {
-        command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/anthos/ssh_key ubuntu@${var.admin_workstation_ip}:/home/ubuntu/cluster/ksa_token.txt /root/anthos"
-     }
+resource "null_resource" "anthos_copy_token" {
+  depends_on = [null_resource.anthos_deploy_cluster]
+  provisioner "local-exec" {
+    command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/anthos/ssh_key ubuntu@${var.admin_workstation_ip}:/home/ubuntu/cluster/ksa_token.txt /root/anthos"
+  }
 }


### PR DESCRIPTION
This PR removes the TF 0.11 style string interpolation within the Anthos template files.

This was missed by https://github.com/packet-labs/google-anthos/pull/76/ because of the `tf.tpl` extension in use (for the nested terraform apply)

This change was formatted with `terraform fmt`, to see the changes with less white-space noise, review with `?w=1`: https://github.com/packet-labs/google-anthos/pull/92/files?w=1

```
null_resource.anthos_deploy_cluster[0] (remote-exec): Warning: Interpolation-only expressions are deprecated

null_resource.anthos_deploy_cluster[0] (remote-exec):   on deploy_cluster.tf line 8, in resource "null_resource" "anthos_deploy_cluster":
null_resource.anthos_deploy_cluster[0] (remote-exec):    8:         private_key = "${file("/root/anthos/ssh_key")}"
null_resource.anthos_deploy_cluster[0] (remote-exec):
null_resource.anthos_deploy_cluster[0] (remote-exec): Terraform 0.11 and earlier required all non-constant expressions to be
null_resource.anthos_deploy_cluster[0] (remote-exec): provided via interpolation syntax, but this pattern is now deprecated. To
null_resource.anthos_deploy_cluster[0] (remote-exec): silence this warning, remove the "${ sequence from the start and the }"
null_resource.anthos_deploy_cluster[0] (remote-exec): sequence from the end of this expression, leaving just the inner expression.

null_resource.anthos_deploy_cluster[0] (remote-exec): Template interpolation syntax is still used to construct strings from
null_resource.anthos_deploy_cluster[0] (remote-exec): expressions when the template includes multiple interpolation sequences or a
null_resource.anthos_deploy_cluster[0] (remote-exec): mixture of literal strings and interpolations. This deprecation applies only
null_resource.anthos_deploy_cluster[0] (remote-exec): to templates that consist entirely of a single interpolation sequence.

null_resource.anthos_deploy_cluster[0] (remote-exec): (and one more similar warning elsewhere)
```