### PR TITLE
Update to Terraform 0.13 and validate terraform scripts in PRs

### DIFF
--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -1,0 +1,40 @@
+name: 'terraform'
+# This workflow verifies that the Terraform configs are valid, 
+# without running Google Anthos or building any Packet infrastructure.
+# https://learn.hashicorp.com/tutorials/terraform/automate-terraform
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    env:
+      TF_IN_AUTOMATION: 1
+      TF_VERSION: ${{ matrix.tf }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tf: [0.13.2]
+    steps:
+    - name: Checkout from Github
+      uses: actions/checkout@v2
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ env.TF_VERSION }}
+    - name: Check Terraform formatting
+      id: fmt
+      run: terraform fmt
+      continue-on-error: true
+    - name: Initialize Terraform, Modules, and Plugins
+      id: init
+      run: terraform init -input=false
+    - name: Validate Terraform syntax
+      id: validate
+      run: terraform validate -no-color
+

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ You can run this script as follows:
 
 Prompts will guide you through the setup. 
  
-## Install Terraform 
-Terraform is just a single binary.  Visit their [download page](https://www.terraform.io/downloads.html), choose your operating system, make the binary executable, and move it into your path. 
+## Install Terraform
+Terraform 0.13 is required. Terraform can be installed with just a single binary.  Visit their [download page](https://www.terraform.io/downloads.html), choose your operating system, make the binary executable, and move it into your path.
  
 Here is an example for **macOS**: 
 ```bash 
-curl -LO https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_darwin_amd64.zip 
-unzip terraform_0.12.18_darwin_amd64.zip 
+curl -LO https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_darwin_amd64.zip
+unzip terraform_0.13.2_darwin_amd64.zip
 chmod +x terraform 
 sudo mv terraform /usr/local/bin/ 
 ``` 

--- a/anthos/cluster/deploy_cluster.tf.tpl
+++ b/anthos/cluster/deploy_cluster.tf.tpl
@@ -6,7 +6,7 @@ resource "null_resource" "anthos_deploy_cluster" {
     type        = "ssh"
     user        = "ubuntu"
     private_key = file("/root/anthos/ssh_key")
-    host        = "${var.admin_workstation_ip}"
+    host        = var.admin_workstation_ip
   }
 
   provisioner "file" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,24 @@
 terraform {
   required_providers {
-    packet = "~> 2.10.1"
+    packet = {
+      source  = "packethost/packet"
+      version = "~> 3.0.1"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Minimum Terraform is bumped to 0.13 and the Packet provider is bumped to 3.0.1.

This also introduces Github workflows as the CI/CD tool and provides basic Terraform validation for PRs. This is step 0 on the way towards https://github.com/packet-labs/google-anthos/issues/91
