### PR TITLE
Changed default facility to ny5

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "esxi_size" {
 }
 
 variable "facility" {
-  default = "sjc1"
+  default = "ny5"
 }
 
 variable "router_os" {


### PR DESCRIPTION
Changed default facility in variables.tf from sjc1 to ny5 as in sjc1 there is no gen 3 hardware